### PR TITLE
Bump striptags

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lodash.merge": "^4.6.1",
     "podcast-categories": "^2.0.0",
     "sentence-splitter": "^3.0.8",
-    "striptags": "^3.1.1",
+    "striptags": "^3.2.0",
     "trim-left": "^1.0.1",
     "trim-right": "^1.0.1",
     "xmlbuilder": "^15.1.1"


### PR DESCRIPTION
This fixes a potential type confusion vulnerability, [detailed at the changelog for the library](https://github.com/ericnorris/striptags/releases/tag/v3.2.0).

Thanks so much!