### PR TITLE
Fix item-scoped <itunes:image> tag

### DIFF
--- a/jsonfeed-to-rss-object.js
+++ b/jsonfeed-to-rss-object.js
@@ -150,7 +150,9 @@ module.exports = function jsonfeedToAtomObject (jf, opts) {
             'itunes:episode': Number.isInteger(get(item, '_itunes.episode')) ? get(item, '_itunes.episode') : null,
             'itunes:subtitle': getSubtitle(item),
             'itunes:summary': getSummary(item),
-            'itunes:image': get(item, '_itunes.image') || get(item, 'image'),
+            'itunes:image': {
+              '@href': get(item, '_itunes.image') || get(item, 'image')
+            },
             'itunes:duration': get(item, '_itunes.duration') || existy(attachment.duration_in_seconds) ? secondsToHMS(attachment.duration_in_seconds) : null,
             'itunes:season': get(item, '_itunes.season') || null,
             'itunes:block': get(item, '_itunes.block') ? 'Yes' : null,


### PR DESCRIPTION
<itunes:image> should be a self-closing tag with the image URL as the href value. Before this change, the episode image would fall back to the provided podcast icon.